### PR TITLE
Don't turn off the sandbox.

### DIFF
--- a/recipes/chromium/Recipe
+++ b/recipes/chromium/Recipe
@@ -30,7 +30,7 @@ cat > ./AppRun <<\EOF
 #!/bin/sh
 HERE=$(dirname $(readlink -f "${0}"))
 export LD_LIBRARY_PATH="${HERE}"/usr/lib:$PATH
-"${HERE}"/usr/bin/chrome --no-sandbox $@
+"${HERE}"/usr/bin/chrome --disable-setuid-sandbox $@
 EOF
 
 chmod a+x ./AppRun


### PR DESCRIPTION
Disable the file-based sandbox only. This way the kernel level sandboxing still takes effect for security.