### PR TITLE
Add Thunderbird Recipe

### DIFF
--- a/recipes/thunderbird/Recipe
+++ b/recipes/thunderbird/Recipe
@@ -1,0 +1,57 @@
+#!/bin/bash -x
+
+# We do not have to build this ourselves since the upstream project 
+# does a great job in providing binaries that run on a great number of systems
+# other upstream projects could learn from Mozilla - how do they do it?
+
+set +e
+
+wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+. ./functions.sh
+
+APP=Thunderbird
+LOWERAPP=${APP,,} 
+
+mkdir -p ./$APP/$APP.AppDir/usr
+cd ./$APP
+
+wget -c --trust-server-names "https://download.mozilla.org/?product=thunderbird-latest&os=linux64"
+VER1=$(ls thunderbird-*.tar.bz2 | cut -d "-" -f 2 | sed -e 's|.tar.bz2||g')
+
+cd ./$APP.AppDir
+tar xfj ../*.tar.bz2
+
+mv thunderbird usr/bin
+
+find . -name default256.png -exec cp \{\} thunderbird.png \;
+
+cat > thunderbird.desktop <<EOF
+[Desktop Entry]
+Type=Application
+Name=Thunderbird Mail
+Icon=thunderbird
+Exec=thunderbird %u
+Categories=Application;Office;Network;Email;
+MimeType=x-scheme-handler/mailto;application/x-xpinstall;
+StartupNotify=true
+EOF
+
+get_apprun
+
+# Thunderbird does not ship with appdata yet, so we fetch it from fedora-appstream upstream
+mkdir -p usr/share/appdata/
+rm usr/share/appdata/mozilla-thunderbird.appdata.xml || true
+wget -c "https://github.com/hughsie/fedora-appstream/blob/master/appdata-extra/desktop/mozilla-thunderbird.appdata.xml" -O usr/share/appdata/mozilla-thunderbird.appdata.xml
+
+GLIBC_NEEDED=$(glibc_needed)
+VERSION=$VER1.glibc$GLIBC_NEEDED
+echo $VERSION
+
+get_desktopintegration $LOWERAPP
+
+rm -rf thunderbird
+
+cd ..
+
+ARCH="x86_64"
+generate_appimage


### PR DESCRIPTION
Thunderbird Recipe, mostly copied from the firefox one.
Runs on Ubuntu 16.04, 12,04 (where it was built), Centos7, Debian stable.
Like Firefox, it won't run on Centos6 because of the glibc version