### PR TITLE
Fix desktop integration in Firefox Recipe

### DIFF
--- a/recipes/firefox/Recipe
+++ b/recipes/firefox/Recipe
@@ -26,6 +26,7 @@ find . -name mozicon128.png -exec cp \{\} firefox.png \;
 
 cat > firefox.desktop <<EOF
 [Desktop Entry]
+Type=Application
 Name=Firefox
 Icon=firefox
 Exec=firefox %u
@@ -37,7 +38,7 @@ EOF
 cat > AppRun <<\EOF
 #!/bin/bash
 HERE="$(dirname "$(readlink -f "${0}")")"
-"$HERE"/usr/bin/firefox $@
+"$HERE"/usr/bin/firefox.wrapper $@
 EOF
 chmod a+x AppRun
 


### PR DESCRIPTION
To get the dialog asking to install the .desktop file I had to fox the following (like discussed in the firefox-dev PR):
Fix firefox.desktop (add Type=Application), or the .desktop is not parsable
Set AppRun to firefox.wrapper to invoke the correct executable