### PR TITLE
Remove disabling the setuid sandbox

### DIFF
--- a/recipes/chromium/Recipe
+++ b/recipes/chromium/Recipe
@@ -30,7 +30,7 @@ cat > ./AppRun <<\EOF
 #!/bin/sh
 HERE=$(dirname $(readlink -f "${0}"))
 export LD_LIBRARY_PATH="${HERE}"/usr/lib:$PATH
-"${HERE}"/usr/bin/chrome --disable-setuid-sandbox $@
+"${HERE}"/usr/bin/chrome $@
 EOF
 
 chmod a+x ./AppRun


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=598454

Initial work has started on fixing the check. Working correctly in the current nightlies so the next stable branch that gets built should have no need for this flag.