### PR TITLE
Use local copy of Recipe

### DIFF
--- a/recipes/scribus/Dockerfile
+++ b/recipes/scribus/Dockerfile
@@ -1,3 +1,3 @@
 FROM centos:6
-ADD https://github.com/probonopd/AppImages/raw/master/recipes/scribus/Recipe /Recipe
+ADD Recipe /Recipe
 RUN bash -ex Recipe && yum clean all && rm -rf /out && rm -rf Scribus*


### PR DESCRIPTION
This works because Docker Hub not only imports the Dockerfile from GitHub, it also imports everything in the directory which contains the Dockerfile (including sub-directories). The advantage is that if I make changes to the Recipe in my fork, and I set up Docker on my fork, then my Docker will use my Recipe instead of yours.