### PR TITLE
Don't blow up when .desktop Exec is an absolute path

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -97,7 +97,7 @@ glibc_needed()
 # Usage: get_desktopintegration name_of_desktop_file_and_exectuable
 get_desktopintegration()
 {
-  REALBIN=$(grep -o "^Exec=.*" *.desktop | sed -e 's|Exec=||g' | cut -d " " -f 1 | head -n 1)
+  REALBIN=$(grep -o "^Exec=.*" *.desktop | sed -e 's|Exec=||g' | cut -d " " -f 1 | head -n 1 | sed 's|^/usr/bin/||g')
   wget -O ./usr/bin/$REALBIN.wrapper https://raw.githubusercontent.com/probonopd/AppImageKit/master/desktopintegration
   chmod a+x ./usr/bin/$REALBIN.wrapper
 


### PR DESCRIPTION
Fixes https://github.com/probonopd/AppImages/issues/163