### PR TITLE
KiCad: Add libssl* and libcrypto* again, because on hosts system are often i…

### DIFF
--- a/recipes/meta/KiCad-nightly.yml
+++ b/recipes/meta/KiCad-nightly.yml
@@ -8,13 +8,13 @@ ingredients:
     - kicad
     - kicad-library
   dist: trusty
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - js-reynaud/ppa-kicad
 
 script:
-  - # Workaround until 
+  - # Workaround until
   - # AppRun.c exports rather than just sets environment variables
   - cat > ./AppRun <<\EOF
   - #!/bin/sh
@@ -24,5 +24,3 @@ script:
   - exec "./bin/kicad" "$@"
   - EOF
   - chmod a+x ./AppRun
-  - rm lib/x86_64-linux-gnu/libssl*
-  - rm lib/x86_64-linux-gnu/libcrypto*

--- a/recipes/meta/KiCad.yml
+++ b/recipes/meta/KiCad.yml
@@ -8,13 +8,13 @@ ingredients:
     - kicad
     - kicad-library
   dist: trusty
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - js-reynaud/kicad-4
 
 script:
-  - # Workaround until 
+  - # Workaround until
   - # AppRun.c exports rather than just sets environment variables
   - cat > ./AppRun <<\EOF
   - #!/bin/sh
@@ -24,5 +24,3 @@ script:
   - exec "./bin/kicad" "$@"
   - EOF
   - chmod a+x ./AppRun
-  - rm lib/x86_64-linux-gnu/libssl*
-  - rm lib/x86_64-linux-gnu/libcrypto*


### PR DESCRIPTION
KiCad: Add libssl* and libcrypto* again, because on hosts system are often installed newer versions which are not compatible (version 'OPENSSL_1.0.0' not found).

References:
https://github.com/probonopd/AppImages/commit/68c83d4036202a1c4fb511ce61e9d0cac79b2862
https://github.com/probonopd/AppImages/commit/6c7473d8cdaaa2572248dcc53d7f617a577ade6b