### PR TITLE
use readelf to find out glibc dependency

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -91,7 +91,7 @@ delete_blacklisted()
 # Echo highest glibc version needed by the executable files in the current directory
 glibc_needed()
 {
-  find . -name *.so -or -name *.so.* -or -type f -executable  -exec strings {} \; | grep ^GLIBC_2 | sed s/GLIBC_//g | sort --version-sort | uniq | tail -n 1
+  find . -name *.so -or -name *.so.* -or -type f -executable  -exec readelf -s {} \; | grep -o '@GLIBC_2.* ' | sed 's/@GLIBC_//g' | sort --version-sort | tail -n 1
 }
 # Add desktop integration
 # Usage: get_desktopintegration name_of_desktop_file_and_exectuable


### PR DESCRIPTION
`strings` checks the whole file, readelf only the symbol table. The result may be incorrect if `strings` finds a line with `GLIBC_2` somewhere else in the file (even if this is very unlikely). Also `uniq` is not needed here.