### PR TITLE
Install the packages in the Dockerfile instead of the Recipe

### DIFF
--- a/recipes/subsurface/Dockerfile
+++ b/recipes/subsurface/Dockerfile
@@ -1,3 +1,15 @@
 FROM centos:6
+RUN yum -y install epel-release git make autoconf automake libtool \
+        libzip-devel libxml2-devel libxslt-devel libsqlite3x-devel \
+        libudev-devel libusbx-devel libcurl-devel libssh2-devel mesa-libGL-devel sqlite-devel \
+        tar gzip which make autoconf automake gstreamer-devel mesa-libEGL coreutils grep wget
+RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+RUN yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils \
+	qt5-qtbase-devel qt5-qtlocation-devel qt5-qtscript-devel qt5-qtwebkit-devel qt5-qtsvg-devel qt5-linguist qt5-qtconnectivity-devel \
+	binutils fuse glibc-devel glib2-devel fuse-devel gcc zlib-devel libpng12 patch
+
+# everything up to here Docker should cache, so we don't need to reinstall
+# all of these huge packages every time.
+
 ADD https://github.com/probonopd/AppImages/raw/master/recipes/subsurface/Recipe /Recipe
 RUN sed -i -e 's|sudo ||g' Recipe && bash -ex Recipe && yum clean all && rm -rf /Subsurface/Subsurface* && rm -rf /out

--- a/recipes/subsurface/Recipe
+++ b/recipes/subsurface/Recipe
@@ -76,12 +76,13 @@ wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./func
 rm functions.sh
 
 if [ -z "$NO_DOWNLOAD" ] ; then
+# this is now done in the Dockerfile which means it will be cached between runs
 # Enable EPEL repository; needed for recent Qt and
 # install dependencies
-sudo yum -y install wget epel-release git make autoconf automake libtool \
-        libzip-devel libxml2-devel libxslt-devel libsqlite3x-devel \
-        libudev-devel libusbx-devel libcurl-devel libssh2-devel mesa-libGL-devel sqlite-devel \
-        tar gzip which make autoconf automake gstreamer-devel mesa-libEGL coreutils grep wget
+#sudo yum -y install epel-release git make autoconf automake libtool \
+#        libzip-devel libxml2-devel libxslt-devel libsqlite3x-devel \
+#        libudev-devel libusbx-devel libcurl-devel libssh2-devel mesa-libGL-devel sqlite-devel \
+#        tar gzip which make autoconf automake gstreamer-devel mesa-libEGL coreutils grep wget
 
 # Determine which architecture should be built
 if [[ "$(/bin/arch)" = "i686" ||  "$(/bin/arch)" = "x86_64" ]] ; then
@@ -102,8 +103,9 @@ git_pull_rebase_helper
 cd ..
 
 # Need a newer gcc, getting it from Developer Toolset 2
-sudo wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
-sudo yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
+# this is now done in the Dockerfile
+#sudo wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+#sudo yum -y install devtoolset-2-gcc devtoolset-2-gcc-c++ devtoolset-2-binutils
 # /opt/rh/devtoolset-2/root/usr/bin/gcc
 # now holds gcc and c++ 4.8.2
 
@@ -118,7 +120,7 @@ fi
 tar xf cmake-*.tar.gz
 
 # EPEL is awesome - fresh Qt5 for old base systems
-sudo yum -y install qt5-qtbase-devel qt5-qtlocation-devel qt5-qtscript-devel qt5-qtwebkit-devel qt5-qtsvg-devel qt5-linguist qt5-qtconnectivity-devel
+#sudo yum -y install qt5-qtbase-devel qt5-qtlocation-devel qt5-qtscript-devel qt5-qtwebkit-devel qt5-qtsvg-devel qt5-linguist qt5-qtconnectivity-devel
 fi
 
 CMAKE_PATH=$(find $PWD/cmake-*/ -type d | head -n 1)bin


### PR DESCRIPTION
This way things get cached by Docker and you don't have to wait as long as you
run things (still takes forever, but not QUITE as long). This of course only
works when running the process on the same system - doesn't help on Travis.

Signed-off-by: Dirk Hohndel <dirk@hohndel.org>