### PR TITLE
Make delete_blacklisted delete symlinks

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -75,7 +75,7 @@ delete_blacklisted()
   BLACKLISTED_FILES=$(wget -q https://github.com/probonopd/AppImages/raw/master/excludelist -O - | sed '/^\s*$/d' | sed '/^#.*$/d')
   echo $BLACKLISTED_FILES
   for FILE in $BLACKLISTED_FILES ; do
-    FOUND=$(find . -type f -name "${FILE}" 2>/dev/null)
+    FOUND=$(find . -xtype f -name "${FILE}" 2>/dev/null)
     if [ ! -z "$FOUND" ] ; then
       echo "Deleting blacklisted ${FOUND}"
       rm -f "${FOUND}"


### PR DESCRIPTION
As discovered in TheAssassin/redeclipse-appimage#3, `delete_blacklisted` does
not delete symlinks to the real `*.so` files. This can cause issues when
an AppImage wants to use the precompiled libraries from a distribution like
Debian which uses symlinks to point to a specific version of a library.

This commit fixes `delete_blacklisted`'s behavior to delete such symlinks.

It is subject to further discussions whether to make the filenames in
`excludelist` wildcards to delete both the symlinks and the files they point
to.
Another approach would be using `readlink -f` to properly resolve the symlinks
and delete their targets. This way one does not have to trust on a wildcard,
although it is very unlike that the globs would delete anything but related
shared object files.