### PR TITLE
Function to bundle libstdc++ and decide at runtime if it's needed

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -105,6 +105,23 @@ get_desktopintegration()
   sed -i -e "s|^Exec=$REALBIN|Exec=$REALBIN.wrapper|g" $1.desktop
 }
 
+# Bundle new libstdc++ and libgcc libraries to support C++11 and C++14
+# apps on older systems. For better backwards compatibility these apps
+# should be build with newer GCC versions on older distributions.
+get_gcclibs()
+{
+  mkdir -p ./usr/lib
+  wget -O ./usr/lib/gcclibs.tar.gz https://github.com/probonopd/AppImages/files/777382/gcclibs.tar.gz
+  (cd ./usr/lib; tar xf gcclibs.tar.gz && rm gcclibs.tar.gz)
+
+  # Install a wrapper script which only adds the bundled GCC libraries to
+  # the search path if they are newer than the libraries available on the system.
+  REALBIN=$(grep -o "^Exec=.*" *.desktop | sed -e 's|Exec=||g' | cut -d " " -f 1 | head -n 1)
+  mv ./usr/bin/$REALBIN ./usr/bin/${REALBIN}-real
+  wget -O ./usr/bin/$REALBIN https://gist.github.com/darealshinji/0fabe0c8d471412aafaebc739f3b9d16/raw/0af5a7266c2afdc47f9b5502bbb4a1f3a50ca418/run.sh
+  chmod a+x ./usr/bin/$REALBIN
+}
+
 # Generate AppImage; this expects $ARCH, $APP and $VERSION to be set
 generate_appimage()
 {

--- a/functions.sh
+++ b/functions.sh
@@ -110,15 +110,15 @@ get_desktopintegration()
 # should be build with newer GCC versions on older distributions.
 get_gcclibs()
 {
-  mkdir -p ./usr/lib
-  wget -O ./usr/lib/gcclibs.tar.gz https://github.com/probonopd/AppImages/files/777382/gcclibs.tar.gz
-  (cd ./usr/lib; tar xf gcclibs.tar.gz && rm gcclibs.tar.gz)
+  mkdir -p ./usr
+  wget -O ./usr/gcc-runtime.tar.gz https://github.com/darealshinji/AppImageKit/releases/download/continuous/gcc-runtime-x86_64.tar.gz
+  (cd ./usr; tar xf gcc-runtime.tar.gz && rm gcc-runtime.tar.gz)
 
   # Install a wrapper script which only adds the bundled GCC libraries to
   # the search path if they are newer than the libraries available on the system.
   REALBIN=$(grep -o "^Exec=.*" *.desktop | sed -e 's|Exec=||g' | cut -d " " -f 1 | head -n 1)
   mv ./usr/bin/$REALBIN ./usr/bin/${REALBIN}-real
-  wget -O ./usr/bin/$REALBIN https://gist.github.com/darealshinji/0fabe0c8d471412aafaebc739f3b9d16/raw/0af5a7266c2afdc47f9b5502bbb4a1f3a50ca418/run.sh
+  wget -O ./usr/bin/$REALBIN https://github.com/darealshinji/AppImageKit/raw/gcc-runtime/run.sh
   chmod a+x ./usr/bin/$REALBIN
 }
 


### PR DESCRIPTION
Should close https://github.com/probonopd/AppImages/issues/173.

Make sure to add [these scripts](https://gist.github.com/darealshinji/0fabe0c8d471412aafaebc739f3b9d16) to one of your repositories and adjust the download URLs in `get_gcclibs()`.

If you want to run a test, you can modify i.e. the wxHexEditor recipe and run the AppImage with the environment variable `DEBUG=1`:
``` diff
--- a/recipes/wxhexeditor/Recipe
+++ b/recipes/wxhexeditor/Recipe
@@ -3,7 +3,8 @@ mkdir -p $APP/$APP.AppDir/usr/bin
 
 cd $APP/
 
-wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+#wget -q https://github.com/probonopd/AppImages/raw/master/functions.sh -O ./functions.sh
+cp $HOME/Downloads/AppImages/functions.sh .
 . ./functions.sh
 
 wget -c "http://downloads.sourceforge.net/project/wxhexeditor/wxHexEditor/v0.23%20Beta/wxHexEditor-v0.23-Linux_x86_64.tar.bz2"
@@ -40,6 +41,8 @@ echo $VERSION
 XAPP=wxHexEditor
 get_desktopintegration $XAPP.desktop
 
+get_gcclibs
+
 cd .. # Go out of AppDir
 
 generate_appimage
```