### PR TITLE
Get rid of dpkg-scanpackages

### DIFF
--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -162,22 +162,22 @@ fi
 
 if [ ! -z "${_ingredients_dist}" ] ; then
   # Some projects provide raw .deb files without a repository
-  # hence we inspect the deb file and add its dependencies to the list of packages that are downloaded later:
+  # hence we inspect the deb file and add its dependencies to the list of packages that are downloaded later
   if [ ! -z "${_ingredients_debs[0]}" ] ; then
     for DEB in "${_ingredients_debs[@]}" ; do
       if [ ! -f $(basename "$DEB") ] ; then
         wget -c $DEB
-        INSTALL="$(dpkg -I $DEB | grep Depends | cut -d':' -f2 | sed 's/,//g')"
       fi
+      URLS="$URLS $DEB"
+      DEB_DEPS="$(dpkg -I $(basename $DEB) | grep Depends | cut -d':' -f2 | sed 's/,//g')"
     done
   fi
 
-  INSTALL="$INSTALL $LOWERAPP"
-  if [ ! -z "${_ingredients_package}" ] ; then
-    INSTALL="${_ingredients_package}"
+  if [ ! -z "${_ingredients_package}" && -z $ ] ; then
+    INSTALL="$DEB_DEPS ${_ingredients_package}"
   fi
   if [ ! -z "${_ingredients_packages}" ] ; then
-    INSTALL=""
+    INSTALL="$DEB_DEPS"
   fi
 
   # If packages are specifically listed, only install these, not a package with the name of the app
@@ -186,7 +186,9 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   fi
 
   apt-get $OPTIONS update || true
-  URLS=$(apt-get $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http")
+  if [ ! -z "$INSTALL" ] ; then
+    URLS="$URLS $(apt-get $OPTIONS -y install --print-uris $INSTALL | cut -d \' -f 2 | grep -e '^http')"
+  fi
   for URL in $URLS ; do
     if [ ! -f $(basename "$URL") ] ; then
       wget -c $URL

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -31,7 +31,6 @@ which wget >/dev/null 2>&1 || ( echo wget missing && exit 1 )
 which grep >/dev/null 2>&1 || ( echo grep missing && exit 1 )
 which sed >/dev/null 2>&1 || ( echo sed missing && exit 1 )
 which cut >/dev/null 2>&1 || ( echo cut missing && exit 1 )
-which dpkg-scanpackages  >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
 
 # If the yaml file doesn't exist locally, get it from GitHub
 if [ ! -f "${!#}" ] ; then
@@ -163,21 +162,17 @@ fi
 
 if [ ! -z "${_ingredients_dist}" ] ; then
   # Some projects provide raw .deb files without a repository
-  # hence we create our own local repository as part of
-  # the AppImage creation process in order to "install"
-  # the package using apt-get as normal
+  # hence we inspect the deb file and add its dependencies to the list of packages that are downloaded later:
   if [ ! -z "${_ingredients_debs[0]}" ] ; then
-  which dpkg-scanpackages >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
     for DEB in "${_ingredients_debs[@]}" ; do
       if [ ! -f $(basename "$DEB") ] ; then
         wget -c $DEB
+        INSTALL="$(dpkg -I $DEB | grep Depends | cut -d':' -f2 | sed 's/,//g')"
       fi
     done
   fi
-  dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
-  echo "deb file:$(readlink -e $PWD) ./" >> sources.list
 
-  INSTALL=$LOWERAPP
+  INSTALL="$INSTALL $LOWERAPP"
   if [ ! -z "${_ingredients_package}" ] ; then
     INSTALL="${_ingredients_package}"
   fi
@@ -187,7 +182,7 @@ if [ ! -z "${_ingredients_dist}" ] ; then
 
   # If packages are specifically listed, only install these, not a package with the name of the app
   if [ ! -z "${_ingredients_packages[0]}" ] ; then
-    INSTALL=${_ingredients_packages[@]}
+    INSTALL="$INSTALL ${_ingredients_packages[@]}"
   fi
 
   apt-get $OPTIONS update || true

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -31,6 +31,7 @@ which wget >/dev/null 2>&1 || ( echo wget missing && exit 1 )
 which grep >/dev/null 2>&1 || ( echo grep missing && exit 1 )
 which sed >/dev/null 2>&1 || ( echo sed missing && exit 1 )
 which cut >/dev/null 2>&1 || ( echo cut missing && exit 1 )
+which dpkg-scanpackages  >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
 
 # If the yaml file doesn't exist locally, get it from GitHub
 if [ ! -f "${!#}" ] ; then
@@ -162,33 +163,35 @@ fi
 
 if [ ! -z "${_ingredients_dist}" ] ; then
   # Some projects provide raw .deb files without a repository
-  # hence we inspect the deb file and add its dependencies to the list of packages that are downloaded later
+  # hence we create our own local repository as part of
+  # the AppImage creation process in order to "install"
+  # the package using apt-get as normal
   if [ ! -z "${_ingredients_debs[0]}" ] ; then
+  which dpkg-scanpackages >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
     for DEB in "${_ingredients_debs[@]}" ; do
       if [ ! -f $(basename "$DEB") ] ; then
         wget -c $DEB
       fi
-      URLS="$URLS $DEB"
-      DEB_DEPS="$DEB_DEPS $(dpkg -I $(basename $DEB) | grep Depends | cut -d':' -f2 | sed 's/,//g')"
     done
   fi
+  dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+  echo "deb file:$(readlink -e $PWD) ./" >> sources.list
 
-  if [ ! -z "${_ingredients_package}" && -z $ ] ; then
-    INSTALL="$DEB_DEPS ${_ingredients_package}"
+  INSTALL=$LOWERAPP
+  if [ ! -z "${_ingredients_package}" ] ; then
+    INSTALL="${_ingredients_package}"
   fi
   if [ ! -z "${_ingredients_packages}" ] ; then
-    INSTALL="$DEB_DEPS"
+    INSTALL=""
   fi
 
   # If packages are specifically listed, only install these, not a package with the name of the app
   if [ ! -z "${_ingredients_packages[0]}" ] ; then
-    INSTALL="$INSTALL ${_ingredients_packages[@]}"
+    INSTALL=${_ingredients_packages[@]}
   fi
 
   apt-get $OPTIONS update || true
-  if [ ! -z "$INSTALL" ] ; then
-    URLS="$URLS $(apt-get $OPTIONS -y install --print-uris $INSTALL | cut -d \' -f 2 | grep -e '^http')"
-  fi
+  URLS=$(apt-get $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http")
   for URL in $URLS ; do
     if [ ! -f $(basename "$URL") ] ; then
       wget -c $URL

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -173,7 +173,6 @@ if [ ! -z "${_ingredients_dist}" ] ; then
     done
   fi
 
-  INSTALL=$LOWERAPP
   if [ ! -z "${_ingredients_package}" && -z $ ] ; then
     INSTALL="$DEB_DEPS ${_ingredients_package}"
   fi

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -31,7 +31,6 @@ which wget >/dev/null 2>&1 || ( echo wget missing && exit 1 )
 which grep >/dev/null 2>&1 || ( echo grep missing && exit 1 )
 which sed >/dev/null 2>&1 || ( echo sed missing && exit 1 )
 which cut >/dev/null 2>&1 || ( echo cut missing && exit 1 )
-which dpkg-scanpackages  >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
 
 # If the yaml file doesn't exist locally, get it from GitHub
 if [ ! -f "${!#}" ] ; then
@@ -41,6 +40,18 @@ if [ ! -f "${!#}" ] ; then
 else
   YAMLFILE="$(readlink -f "${!#}")"
 fi
+
+# Lightweight bash-only dpkg-scanpackages replacement
+scanpackages() {
+  for deb in *.deb ; do
+    dpkg -I $deb | sed 's/^ *//g' | grep -i -E '(package|version|installed-size|architecture|depends|priority):'
+    echo "Filename: $(readlink -f $deb)"
+    echo "MD5sum: $(md5sum -b $deb | cut -d' ' -f1)"
+    echo "SHA1: $(sha1sum -b $deb | cut -d' ' -f1)"
+    echo "SHA256: $(sha256sum -b $deb | cut -d' ' -f1)"
+    echo
+  done
+}
 
 # Function to parse yaml
 # https://gist.github.com/epiloque/8cf512c6d64641bde388
@@ -167,14 +178,13 @@ if [ ! -z "${_ingredients_dist}" ] ; then
   # the AppImage creation process in order to "install"
   # the package using apt-get as normal
   if [ ! -z "${_ingredients_debs[0]}" ] ; then
-  which dpkg-scanpackages >/dev/null 2>&1 || ( echo dpkg-scanpackages missing && exit 1 )
     for DEB in "${_ingredients_debs[@]}" ; do
       if [ ! -f $(basename "$DEB") ] ; then
         wget -c $DEB
       fi
     done
   fi
-  dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+  scanpackages | gzip -9c > Packages.gz
   echo "deb file:$(readlink -e $PWD) ./" >> sources.list
 
   INSTALL=$LOWERAPP

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -169,10 +169,11 @@ if [ ! -z "${_ingredients_dist}" ] ; then
         wget -c $DEB
       fi
       URLS="$URLS $DEB"
-      DEB_DEPS="$(dpkg -I $(basename $DEB) | grep Depends | cut -d':' -f2 | sed 's/,//g')"
+      DEB_DEPS="$DEB_DEPS $(dpkg -I $(basename $DEB) | grep Depends | cut -d':' -f2 | sed 's/,//g')"
     done
   fi
 
+  INSTALL=$LOWERAPP
   if [ ! -z "${_ingredients_package}" && -z $ ] ; then
     INSTALL="$DEB_DEPS ${_ingredients_package}"
   fi


### PR DESCRIPTION
This PR attempts to remove the need for a local package repository in order to be able to download the dependencies of meta recipes. Instead of using `dpkg-scanpackages` to create an old-style Debian repository, it uses `dpkg -I` to inspect the `.deb`s and adds these to the list of packages downloaded using `apt-get install --print-uris`.