### PR TITLE
More improvements

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -146,7 +146,8 @@ generate_appimage()
   chmod a+x ./AppImageAssistant
   mkdir -p ../out || true
   rm ../out/$APP"-"$VERSION"-x86_64.AppImage" 2>/dev/null || true
-  ./AppImageAssistant ./$APP.AppDir/ ../out/$APP"-"$VERSION"-"$ARCH".AppImage"
+  ${GLIBC_NEEDED:−$(glibc_needed)}
+  ./AppImageAssistant ./$APP.AppDir/ ../out/$APP"-"$VERSION".glibc"$GLIBC_NEEDED"-"$ARCH".AppImage"
 }
 
 # Generate AppImage type 2
@@ -170,9 +171,10 @@ generate_type2_appimage()
     tar xf data.tar.gz
     sudo chown -R $USER .gnu*
     mv $HOME/.gnu* $HOME/.gnu_old ; mv .gnu* $HOME/
-    VERSION=$VERSION ./appimagetool -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    ${GLIBC_NEEDED:−$(glibc_needed)}
+    VERSION=$VERSION.glibc$GLIBC_NEEDED ./appimagetool -n -s --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   else
-    VERSION=$VERSION ./appimagetool -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
+    VERSION=$VERSION.glibc$GLIBC_NEEDED ./appimagetool -n --bintray-user $BINTRAY_USER --bintray-repo $BINTRAY_REPO -v ./$APP.AppDir/
   fi
   set -x
   mkdir -p ../out/ || true

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -38,7 +38,7 @@ if [ ! -f "${!#}" ] ; then
   rm -f "$YAMLFILE"
   wget -q "https://github.com/probonopd/AppImages/raw/master/recipes/meta/${!#}.yml" -O "$YAMLFILE"
 else
-  YAMLFILE="$(readlink -f "${!#}")"
+  YAMLFILE=$(readlink -f "${!#}")
 fi
 
 # Lightweight bash-only dpkg-scanpackages replacement

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -220,7 +220,7 @@ if [ ! -z "${_ingredients_dist}" ] ; then
     dltool=wget
   fi
 
-  $dltool -i- <<<"$URLS"
+  $dltool -c -i- <<<"$URLS"
 fi
 
 mkdir -p ./$APP.AppDir/

--- a/recipes/meta/Recipe
+++ b/recipes/meta/Recipe
@@ -214,11 +214,13 @@ if [ ! -z "${_ingredients_dist}" ] ; then
 
   apt-get $OPTIONS update || true
   URLS=$(apt-get $OPTIONS -y install --print-uris $INSTALL | cut -d "'" -f 2 | grep -e "^http")
-  for URL in $URLS ; do
-    if [ ! -f $(basename "$URL") ] ; then
-      wget -c $URL
-    fi
-  done
+  if which aria2c &>/dev/null; then
+    dltool=aria2c
+  else
+    dltool=wget
+  fi
+
+  $dltool -i- <<<"$URLS"
 fi
 
 mkdir -p ./$APP.AppDir/


### PR DESCRIPTION
This PR:

 * includes a small fix with a variable substitution in the meta recipe
 * makes the `generate*appimage` helpers automatically include the glibc version in the resulting filename
 * drastically increases `.deb` download speed