### PR TITLE
Remove obsolete sed command

### DIFF
--- a/recipes/meta/CAMotics.yml
+++ b/recipes/meta/CAMotics.yml
@@ -23,4 +23,3 @@ ingredients:
 
 script:
   - mv CAMotics.desktop camotics.desktop
-  - sed -i 's/Categories=Science/Categories=Science;/' camotics.desktop

--- a/recipes/meta/LibreCAD-daily.yml
+++ b/recipes/meta/LibreCAD-daily.yml
@@ -6,11 +6,10 @@ ingredients:
   packages:
     - librecad
     - appmenu-qt5
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - librecad-dev/librecad-daily
 
 script:
   - cp usr/share/icons/hicolor/scalable/apps/librecad.svg .
-  - sed -i -e 's|MimeType=image/vnd.dxf|MimeType=image/vnd.dxf;|g' librecad.desktop

--- a/recipes/meta/LibreCAD.yml
+++ b/recipes/meta/LibreCAD.yml
@@ -6,11 +6,10 @@ ingredients:
   packages:
     - librecad
     - appmenu-qt
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main universe
   ppas:
     - librecad-dev/librecad-stable
 
 script:
   - cp usr/share/icons/hicolor/scalable/apps/librecad.svg .
-  - sed -i -e 's|MimeType=image/vnd.dxf|MimeType=image/vnd.dxf;|g' librecad.desktop

--- a/recipes/meta/Mpv.yml
+++ b/recipes/meta/Mpv.yml
@@ -6,7 +6,7 @@ binpatch: true
 
 ingredients:
   dist: trusty
-  sources: 
+  sources:
     - deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse
   ppas:
     - mc3man/mpv-tests
@@ -14,7 +14,6 @@ ingredients:
 script:
   - wget "https://yt-dl.org/downloads/latest/youtube-dl" -O usr/bin/youtube-dl
   - chmod 0755 usr/bin/youtube-dl
-  - sed -i -e 's|Help;Bindings;Scripts;About;Notes|Help;Bindings;Scripts;About;Notes;|g' mpv.desktop
   - sed -i -e 's|TargetEnvironment|X-TargetEnvironment|g' mpv.desktop
   - sed -i -e 's|Desktop Action|X-Disabled Desktop Action|g' mpv.desktop
   - sed -i -e 's|^Actions=|X-Disabled-Actions=|g' mpv.desktop

--- a/recipes/meta/RedEclipse.yml
+++ b/recipes/meta/RedEclipse.yml
@@ -8,7 +8,6 @@ ingredients:
 
 script:
   - cp usr/share/applications/redeclipse.desktop .
-  - sed -i '/Keywords/s/$/;/' redeclipse.desktop
   - mv usr/games/redeclipse usr/bin/
   - sed -i '/done/a export REDECLIPSE_BRANCH=AppImage' usr/bin/redeclipse
   - sed -i 's|/usr/|$(dirname "$0")/../|g' usr/bin/redeclipse


### PR DESCRIPTION
Due to the fix committed in 041d232, these commands are no longer necessary, and can be removed safely.