### PR TITLE
Handle the case with subdirs in usr/lib64.

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -76,6 +76,9 @@ move_lib()
 {
   mkdir -p ./usr/lib ./lib && find ./lib/ -exec cp -v --parents -rfL {} ./usr/ \; && rm -rf ./lib
   mkdir -p ./usr/lib ./lib64 && find ./lib64/ -exec cp -v --parents -rfL {} ./usr/ \; && rm -rf ./lib64
+  # Move libs from subdirs of usr/lib64 into usr/lib64 and delete those subdirs
+  find usr/lib64 -mindepth 2 -type f -name '*.so*' -exec mv {} usr/lib64 \;
+  find usr/lib64 -mindepth 1 -type d -delete
 }
 
 # Delete blacklisted files


### PR DESCRIPTION
I've seen it on Centos 7-based appimage builds, when there are /usr/lib64/pulseaudio, /usr/lib64/samba and such, and those paths are not in LD_LIBRARY_PATH of appimage. As suggested, moving all those libraries from subdirs of usr/lib64 into usr/lib64 itself, and delete those subdirs.

I have tested it only on Centos 7-based appimage build.

Please review, thanks!