### PR TITLE
Add recipes for multiple versions of the PHP CLI

### DIFF
--- a/recipes/meta/php5.6.yml
+++ b/recipes/meta/php5.6.yml
@@ -1,0 +1,57 @@
+app: php5.6
+
+ingredients:
+  dist: precise
+  sources:
+    - deb http://ftp.fau.de/ubuntu/ precise main universe
+  ppas:
+    - ondrej/php
+  packages:
+    - php5.6
+    - php5.6-bcmath
+    - php5.6-bz2
+    - php5.6-cli
+    - php5.6-common
+    - php5.6-curl
+    - php5.6-dba
+    - php5.6-dev
+    - php5.6-enchant
+    - php5.6-gd
+    - php5.6-gmp
+    - php5.6-imap
+    - php5.6-interbase
+    - php5.6-intl
+    - php5.6-json
+    - php5.6-ldap
+    - php5.6-mbstring
+    - php5.6-mcrypt
+    - php5.6-mysql
+    - php5.6-odbc
+    - php5.6-opcache
+    - php5.6-pgsql
+    - php5.6-phpdbg
+    - php5.6-pspell
+    - php5.6-readline
+    - php5.6-recode
+    - php5.6-snmp
+    - php5.6-soap
+    - php5.6-sqlite3
+    - php5.6-sybase
+    - php5.6-tidy
+    - php5.6-xml
+    - php5.6-xmlrpc
+    - php5.6-xsl
+    - php5.6-zip
+
+script:
+  -  dpkg -I php*-cli*_amd64.deb | grep "Version:" | cut -d':' -f2 | cut -d'+' -f1 | sed 's/^[ ]*//g' > VERSION
+  - wget -c -O php.png https://php.net/images/logos/php-icon.png
+  - cat > php5.6.desktop <<\EOF
+  - [Desktop Entry]
+  - Type=Application
+  - Terminal=true
+  - Name=php5.6
+  - Exec=php-cgi5.6
+  - Categories=Development;
+  - Icon=php
+  - EOF

--- a/recipes/meta/php5.6.yml
+++ b/recipes/meta/php5.6.yml
@@ -1,4 +1,5 @@
 app: php5.6
+union: true
 
 ingredients:
   dist: precise

--- a/recipes/meta/php5.6.yml
+++ b/recipes/meta/php5.6.yml
@@ -51,7 +51,7 @@ script:
   - Type=Application
   - Terminal=true
   - Name=php5.6
-  - Exec=php-cgi5.6
+  - Exec=php5.6
   - Categories=Development;
   - Icon=php
   - EOF

--- a/recipes/meta/php7.1.yml
+++ b/recipes/meta/php7.1.yml
@@ -1,4 +1,5 @@
 app: php7.1
+union: true
 
 ingredients:
   dist: precise

--- a/recipes/meta/php7.1.yml
+++ b/recipes/meta/php7.1.yml
@@ -1,0 +1,57 @@
+app: php7.1
+
+ingredients:
+  dist: precise
+  sources:
+    - deb http://ftp.fau.de/ubuntu/ precise main universe
+  ppas:
+    - ondrej/php
+  packages:
+    - php7.1
+    - php7.1-bcmath
+    - php7.1-bz2
+    - php7.1-cli
+    - php7.1-common
+    - php7.1-curl
+    - php7.1-dba
+    - php7.1-dev
+    - php7.1-enchant
+    - php7.1-gd
+    - php7.1-gmp
+    - php7.1-imap
+    - php7.1-interbase
+    - php7.1-intl
+    - php7.1-json
+    - php7.1-ldap
+    - php7.1-mbstring
+    - php7.1-mcrypt
+    - php7.1-mysql
+    - php7.1-odbc
+    - php7.1-opcache
+    - php7.1-pgsql
+    - php7.1-phpdbg
+    - php7.1-pspell
+    - php7.1-readline
+    - php7.1-recode
+    - php7.1-snmp
+    - php7.1-soap
+    - php7.1-sqlite3
+    - php7.1-sybase
+    - php7.1-tidy
+    - php7.1-xml
+    - php7.1-xmlrpc
+    - php7.1-xsl
+    - php7.1-zip
+
+script:
+  -  dpkg -I php*-cli*_amd64.deb | grep "Version:" | cut -d':' -f2 | cut -d'+' -f1 | sed 's/^[ ]*//g' > VERSION
+  - wget -c -O php.png https://php.net/images/logos/php-icon.png
+  - cat > php7.1.desktop <<\EOF
+  - [Desktop Entry]
+  - Type=Application
+  - Terminal=true
+  - Name=php7.1
+  - Exec=php-cgi7.1
+  - Categories=Development;
+  - Icon=php
+  - EOF

--- a/recipes/meta/php7.1.yml
+++ b/recipes/meta/php7.1.yml
@@ -51,7 +51,7 @@ script:
   - Type=Application
   - Terminal=true
   - Name=php7.1
-  - Exec=php-cgi7.1
+  - Exec=php7.1
   - Categories=Development;
   - Icon=php
   - EOF


### PR DESCRIPTION
This commit adds a few recipes that build AppImages for several versions of the PHP CLI.

The AppImages contain all the PHP extensions that can be built from the Debian PHP source packages.