### PR TITLE
Fix functions.sh for /bin/sh on Ubuntu Trusty

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -239,7 +239,7 @@ tmpfile=$( mktemp -t transferXXX ); if tty -s; then basefile=$(basename "$1" | s
 # Patch binary files; fill with padding if replacement is shorter than original
 # http://everydaywithlinux.blogspot.de/2012/11/patch-strings-in-binary-files-with-sed.html
 # Example: patch_strings_in_file foo "/usr/local/lib/foo" "/usr/lib/foo"
-function patch_strings_in_file() {
+patch_strings_in_file() {
     local FILE="$1"
     local PATTERN="$2"
     local REPLACEMENT="$3"


### PR DESCRIPTION
Trying to use `/bin/sh` to run functions.sh causes this error to be displayed:

> build/appimage_functions.sh: 242: build/appimage_functions.sh: Syntax error: "(" unexpected

This appears to be because the `patch_strings_in_file` function is declared with the "function" keyword. None of the other functions in the file use that declaration style and removing the word "function" from the declaration fixes it.