### PR TITLE
delete_blacklisted(): remove all text after '#'

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -81,7 +81,7 @@ move_lib()
 # Delete blacklisted files
 delete_blacklisted()
 {
-  BLACKLISTED_FILES=$( cat_file_from_url https://github.com/probonopd/AppImages/raw/master/excludelist | sed '/^\s*$/d' | sed '/^#.*$/d')
+  BLACKLISTED_FILES=$(cat_file_from_url https://github.com/probonopd/AppImages/raw/master/excludelist | sed 's|#.*||g')
   echo $BLACKLISTED_FILES
   for FILE in $BLACKLISTED_FILES ; do
     FOUND=$(find . -xtype f -name "${FILE}" 2>/dev/null)


### PR DESCRIPTION
Otherwise a comment on the same line as a library name will not be removed.
And empty line don't need to be removed explicitly, the shell will automatically handle that.