### PR TITLE
Use default icon name

### DIFF
--- a/recipes/meta/FreeCAD-nightly.yml
+++ b/recipes/meta/FreeCAD-nightly.yml
@@ -21,7 +21,7 @@ script:
   - sed -i -e 's@FreeCAD Daily@FreeCAD@g' freecad-daily.desktop
   - sed -i -e 's@/usr/bin/@@g' freecad-daily.desktop
   - sed -i -e 's@Path=@# Path=@g' freecad-daily.desktop
-  - sed -i -e 's@Icon=freecad@Icon=freecad-daily@g' freecad-daily.desktop
+  # - sed -i -e 's@Icon=freecad@Icon=freecad-daily@g' freecad-daily.desktop
   - cp ./usr/share/icons/hicolor/64x64/apps/freecad-daily.png .
   - # Dear upstream developers, please use relative rather than absolute paths
   - # then binary patching like this will become unneccessary


### PR DESCRIPTION
Currently AppImage build procedure fails with freecad-daily-daily{.png,.svg,.svgz,.xpm} not present but defined in desktop file. Using default icon name should fix the issue.

https://forum.freecadweb.org/viewtopic.php?f=4&t=22606